### PR TITLE
build: update lombok gradle plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ plugins {
     id "io.spring.dependency-management" version '1.1.7'
 	id 'java'
 	id 'jacoco'
-	id "io.freefair.lombok" version "6.6.3"
+	id "io.freefair.lombok" version "8.14.2"
 }
 
 group = 'de.unimarburg.diz'


### PR DESCRIPTION
Updates the gradle plugin for lombok to get rid of compilation issues using newer installed JDK versions > 17.